### PR TITLE
Add SetDeleteBehavior option to EnumLookupOptions

### DIFF
--- a/src/SpatialFocus.EntityFrameworkCore.Extensions/EnumLookupExtension.cs
+++ b/src/SpatialFocus.EntityFrameworkCore.Extensions/EnumLookupExtension.cs
@@ -67,7 +67,7 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 				string keyName = enumOptions.UseNumberLookup ? nameof(EnumWithNumberLookup<Enum>.Id)
 					: nameof(EnumWithStringLookup<Enum>.Id);
 
-				modelBuilder.Entity(entityType.Name).HasOne(concreteType).WithMany().HasPrincipalKey(keyName).HasForeignKey(property.Name);
+				modelBuilder.Entity(entityType.Name).HasOne(concreteType).WithMany().HasPrincipalKey(keyName).HasForeignKey(property.Name).OnDelete(enumOptions.DeleteBehavior);
 
 				if (enumOptions.UseNumberLookup)
 				{

--- a/src/SpatialFocus.EntityFrameworkCore.Extensions/EnumLookupExtension.cs
+++ b/src/SpatialFocus.EntityFrameworkCore.Extensions/EnumLookupExtension.cs
@@ -64,10 +64,16 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 				string tableName = enumOptions.NamingFunction(typeName);
 				enumLookupBuilder.ToTable(tableName);
 
-				string keyName = enumOptions.UseNumberLookup ? nameof(EnumWithNumberLookup<Enum>.Id)
+				string keyName = enumOptions.UseNumberLookup
+					? nameof(EnumWithNumberLookup<Enum>.Id)
 					: nameof(EnumWithStringLookup<Enum>.Id);
 
-				modelBuilder.Entity(entityType.Name).HasOne(concreteType).WithMany().HasPrincipalKey(keyName).HasForeignKey(property.Name).OnDelete(enumOptions.DeleteBehavior);
+				modelBuilder.Entity(entityType.Name)
+					.HasOne(concreteType)
+					.WithMany()
+					.HasPrincipalKey(keyName)
+					.HasForeignKey(property.Name)
+					.OnDelete(enumOptions.DeleteBehavior);
 
 				if (enumOptions.UseNumberLookup)
 				{

--- a/src/SpatialFocus.EntityFrameworkCore.Extensions/EnumLookupOptions.cs
+++ b/src/SpatialFocus.EntityFrameworkCore.Extensions/EnumLookupOptions.cs
@@ -31,15 +31,22 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 
 		internal Func<string, string> NamingFunction => name => this.postProcessingTableNamingFunction(this.namingFunction(name));
 
+		internal DeleteBehavior DeleteBehavior { get; private set; }
+
 		internal bool UseEnumsWithAttributesOnly { get; private set; }
 
 		internal bool UseNumberLookup { get; private set; }
 
-		internal DeleteBehavior DeleteBehavior { get; private set; }
-
 		public EnumLookupOptions Pluralize()
 		{
 			this.postProcessingTableNamingFunction = name => name.Pluralize(false);
+
+			return this;
+		}
+
+		public EnumLookupOptions SetDeleteBehavior(DeleteBehavior deleteBehavior)
+		{
+			DeleteBehavior = deleteBehavior;
 
 			return this;
 		}
@@ -75,13 +82,6 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 		public EnumLookupOptions UseStringAsIdentifier()
 		{
 			UseNumberLookup = false;
-
-			return this;
-		}
-
-		public EnumLookupOptions SetDeleteBehavior(DeleteBehavior deleteBehavior)
-		{
-			DeleteBehavior = deleteBehavior;
 
 			return this;
 		}

--- a/src/SpatialFocus.EntityFrameworkCore.Extensions/EnumLookupOptions.cs
+++ b/src/SpatialFocus.EntityFrameworkCore.Extensions/EnumLookupOptions.cs
@@ -7,6 +7,7 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 {
 	using System;
 	using Humanizer;
+	using Microsoft.EntityFrameworkCore;
 
 	public class EnumLookupOptions
 	{
@@ -22,6 +23,7 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 				enumOptions.SetNamingScheme(NamingScheme.SnakeCase);
 				enumOptions.UseNumberLookup = true;
 				enumOptions.UseEnumsWithAttributesOnly = false;
+				enumOptions.DeleteBehavior = DeleteBehavior.Cascade;
 
 				return enumOptions;
 			}
@@ -32,6 +34,8 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 		internal bool UseEnumsWithAttributesOnly { get; private set; }
 
 		internal bool UseNumberLookup { get; private set; }
+
+		internal DeleteBehavior DeleteBehavior { get; private set; }
 
 		public EnumLookupOptions Pluralize()
 		{
@@ -71,6 +75,13 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 		public EnumLookupOptions UseStringAsIdentifier()
 		{
 			UseNumberLookup = false;
+
+			return this;
+		}
+
+		public EnumLookupOptions SetDeleteBehavior(DeleteBehavior deleteBehavior)
+		{
+			DeleteBehavior = deleteBehavior;
 
 			return this;
 		}


### PR DESCRIPTION
EF Core DeleteBehavior defaults to `DeleteBehavior.Cascade` and [currently there is no way to change this setting globally](https://github.com/aspnet/EntityFrameworkCore/issues/4299). The new `SetDeleteBehavior` option allows users to specify the `DeleteBehavior` for the generated FKs while keeping `Cascade` as the default behavior for compatibility.

One potential use case is when introducing the auto-generated FK with the default `Cascade` behavior would result in an error with SQL Server (_Introducing FOREIGN KEY constraint 'fk_two' on table 'table2' may cause cycles or multiple cascade paths..._).