### PR TITLE
Upgrade to target .NET 6

### DIFF
--- a/samples/SpatialFocus.EntityFrameworkCore.Extensions.SQLiteDemo/SpatialFocus.EntityFrameworkCore.Extensions.SQLiteDemo.csproj
+++ b/samples/SpatialFocus.EntityFrameworkCore.Extensions.SQLiteDemo/SpatialFocus.EntityFrameworkCore.Extensions.SQLiteDemo.csproj
@@ -2,11 +2,11 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>netcoreapp3.0</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SpatialFocus.EntityFrameworkCore.Extensions/NamingExtension.cs
+++ b/src/SpatialFocus.EntityFrameworkCore.Extensions/NamingExtension.cs
@@ -29,9 +29,15 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 				}
 
 				// Properties
+#if NET5_0_OR_GREATER
 				entity.GetProperties()
 					.ToList()
 					.ForEach(x => x.SetColumnName(namingOptions.ColumnNamingFunction(x.GetColumnBaseName())));
+#else
+				entity.GetProperties()
+					.ToList()
+					.ForEach(x => x.SetColumnName(namingOptions.ColumnNamingFunction(x.GetColumnName())));
+#endif
 
 				// Primary and Alternative keys
 				entity.GetKeys().ToList().ForEach(x => x.SetName(namingOptions.ConstraintNamingFunction(x.GetName())));
@@ -42,9 +48,15 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 					.ForEach(x => x.SetConstraintName(namingOptions.ConstraintNamingFunction(x.GetConstraintName())));
 
 				// Indices
+#if NET5_0_OR_GREATER
 				entity.GetIndexes()
 					.ToList()
 					.ForEach(x => x.SetDatabaseName(namingOptions.ConstraintNamingFunction(x.GetDatabaseName())));
+#else
+				entity.GetIndexes()
+					.ToList()
+					.ForEach(x => x.SetName(namingOptions.ConstraintNamingFunction(x.GetName())));
+#endif
 			}
 		}
 	}

--- a/src/SpatialFocus.EntityFrameworkCore.Extensions/NamingExtension.cs
+++ b/src/SpatialFocus.EntityFrameworkCore.Extensions/NamingExtension.cs
@@ -29,13 +29,11 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 				}
 
 				// Properties
-#if NET5_0_OR_GREATER
 				entity.GetProperties()
 					.ToList()
+#if NET5_0_OR_GREATER
 					.ForEach(x => x.SetColumnName(namingOptions.ColumnNamingFunction(x.GetColumnBaseName())));
 #else
-				entity.GetProperties()
-					.ToList()
 					.ForEach(x => x.SetColumnName(namingOptions.ColumnNamingFunction(x.GetColumnName())));
 #endif
 
@@ -48,13 +46,11 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 					.ForEach(x => x.SetConstraintName(namingOptions.ConstraintNamingFunction(x.GetConstraintName())));
 
 				// Indices
-#if NET5_0_OR_GREATER
 				entity.GetIndexes()
 					.ToList()
+#if NET5_0_OR_GREATER
 					.ForEach(x => x.SetDatabaseName(namingOptions.ConstraintNamingFunction(x.GetDatabaseName())));
 #else
-				entity.GetIndexes()
-					.ToList()
 					.ForEach(x => x.SetName(namingOptions.ConstraintNamingFunction(x.GetName())));
 #endif
 			}

--- a/src/SpatialFocus.EntityFrameworkCore.Extensions/NamingExtension.cs
+++ b/src/SpatialFocus.EntityFrameworkCore.Extensions/NamingExtension.cs
@@ -31,7 +31,7 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 				// Properties
 				entity.GetProperties()
 					.ToList()
-					.ForEach(x => x.SetColumnName(namingOptions.ColumnNamingFunction(x.GetColumnName())));
+					.ForEach(x => x.SetColumnName(namingOptions.ColumnNamingFunction(x.GetColumnBaseName())));
 
 				// Primary and Alternative keys
 				entity.GetKeys().ToList().ForEach(x => x.SetName(namingOptions.ConstraintNamingFunction(x.GetName())));
@@ -44,7 +44,7 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions
 				// Indices
 				entity.GetIndexes()
 					.ToList()
-					.ForEach(x => x.SetName(namingOptions.ConstraintNamingFunction(x.GetName())));
+					.ForEach(x => x.SetDatabaseName(namingOptions.ConstraintNamingFunction(x.GetDatabaseName())));
 			}
 		}
 	}

--- a/src/SpatialFocus.EntityFrameworkCore.Extensions/SpatialFocus.EntityFrameworkCore.Extensions.csproj
+++ b/src/SpatialFocus.EntityFrameworkCore.Extensions/SpatialFocus.EntityFrameworkCore.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net6.0</TargetFramework>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -33,8 +33,8 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="Humanizer.Core" Version="2.8.26" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SpatialFocus.EntityFrameworkCore.Extensions/SpatialFocus.EntityFrameworkCore.Extensions.csproj
+++ b/src/SpatialFocus.EntityFrameworkCore.Extensions/SpatialFocus.EntityFrameworkCore.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>netstandard2.1;net5.0;net6.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -33,6 +33,22 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 		<PackageReference Include="Humanizer.Core" Version="2.8.26" />
+	</ItemGroup>
+
+	<!-- Conditionally obtain references for the netstandard2.1 target -->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="3.1.0" />
+	</ItemGroup>
+
+	<!-- Conditionally obtain references for the net5.0 target -->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.12" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.12" />
+	</ItemGroup>
+
+	<!-- Conditionally obtain references for the net6.0 target -->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
 	</ItemGroup>

--- a/test/SpatialFocus.EntityFrameworkCore.Extensions.Test/NamingOptionsTest.cs
+++ b/test/SpatialFocus.EntityFrameworkCore.Extensions.Test/NamingOptionsTest.cs
@@ -28,15 +28,42 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions.Test
 			return context;
 		}
 
+#if NET5_0_OR_GREATER
 		[Fact]
 		public void OverrideColumnNaming()
 		{
 			ProductContext context = GetContext(namingOptions: new NamingOptions().OverrideColumnNaming(NamingScheme.SnakeCase));
 
 			IEntityType findEntityType = context.Model.FindEntityType(typeof(ProductTag));
+
+			Assert.Equal("product_tag_id", findEntityType.FindProperty(nameof(ProductTag.ProductTagId)).GetColumnBaseName());
+		}
+#else
+		[Fact]
+		public void OverrideColumnNaming()
+		{
+			ProductContext context = GetContext(namingOptions: new NamingOptions().OverrideColumnNaming(NamingScheme.SnakeCase));
+
+			IEntityType findEntityType = context.Model.FindEntityType(typeof(ProductTag));
+
 			Assert.Equal("product_tag_id", findEntityType.FindProperty(nameof(ProductTag.ProductTagId)).GetColumnName());
 		}
+#endif
 
+#if NET5_0_OR_GREATER
+		[Fact]
+		public void OverrideConstraintNaming()
+		{
+			ProductContext context = GetContext(namingOptions: new NamingOptions().OverrideConstraintNaming(NamingScheme.SnakeCase));
+
+			IEntityType findEntityType = context.Model.FindEntityType(typeof(ProductTag));
+			Assert.Equal("ProductTag", findEntityType.GetTableName());
+			Assert.Equal("ProductTagId", findEntityType.FindProperty(nameof(ProductTag.ProductTagId)).GetColumnBaseName());
+			Assert.True(findEntityType.GetKeys().All(x => x.GetName() == NamingScheme.SnakeCase(x.GetDefaultName())));
+			Assert.True(findEntityType.GetForeignKeys().All(x => x.GetConstraintName() == NamingScheme.SnakeCase(x.GetDefaultName())));
+			Assert.True(findEntityType.GetIndexes().All(x => x.GetDatabaseName() == NamingScheme.SnakeCase(x.GetDefaultDatabaseName())));
+		}
+#else
 		[Fact]
 		public void OverrideConstraintNaming()
 		{
@@ -49,6 +76,7 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions.Test
 			Assert.True(findEntityType.GetForeignKeys().All(x => x.GetConstraintName() == NamingScheme.SnakeCase(x.GetDefaultName())));
 			Assert.True(findEntityType.GetIndexes().All(x => x.GetName() == NamingScheme.SnakeCase(x.GetDefaultName())));
 		}
+#endif
 
 		[Fact]
 		public void OverrideTableNaming()
@@ -77,6 +105,20 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions.Test
 			Assert.Equal("product_tags", findEntityType.GetTableName());
 		}
 
+#if NET5_0_OR_GREATER
+		[Fact]
+		public void SetNamingScheme()
+		{
+			ProductContext context = GetContext(namingOptions: new NamingOptions().SetNamingScheme(NamingScheme.SnakeCase));
+
+			IEntityType findEntityType = context.Model.FindEntityType(typeof(ProductTag));
+			Assert.Equal("product_tag", findEntityType.GetTableName());
+			Assert.Equal("product_tag_id", findEntityType.FindProperty(nameof(ProductTag.ProductTagId)).GetColumnBaseName());
+			Assert.True(findEntityType.GetKeys().All(x => x.GetName() == NamingScheme.SnakeCase(x.GetDefaultName())));
+			Assert.True(findEntityType.GetForeignKeys().All(x => x.GetConstraintName() == NamingScheme.SnakeCase(x.GetDefaultName())));
+			Assert.True(findEntityType.GetIndexes().All(x => x.GetDatabaseName() == NamingScheme.SnakeCase(x.GetDefaultDatabaseName())));
+		}
+#else
 		[Fact]
 		public void SetNamingScheme()
 		{
@@ -89,6 +131,7 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions.Test
 			Assert.True(findEntityType.GetForeignKeys().All(x => x.GetConstraintName() == NamingScheme.SnakeCase(x.GetDefaultName())));
 			Assert.True(findEntityType.GetIndexes().All(x => x.GetName() == NamingScheme.SnakeCase(x.GetDefaultName())));
 		}
+#endif
 
 		[Fact]
 		public void MultipleProviders()

--- a/test/SpatialFocus.EntityFrameworkCore.Extensions.Test/NamingOptionsTest.cs
+++ b/test/SpatialFocus.EntityFrameworkCore.Extensions.Test/NamingOptionsTest.cs
@@ -28,55 +28,42 @@ namespace SpatialFocus.EntityFrameworkCore.Extensions.Test
 			return context;
 		}
 
-#if NET5_0_OR_GREATER
 		[Fact]
 		public void OverrideColumnNaming()
 		{
 			ProductContext context = GetContext(namingOptions: new NamingOptions().OverrideColumnNaming(NamingScheme.SnakeCase));
 
 			IEntityType findEntityType = context.Model.FindEntityType(typeof(ProductTag));
-
+#if NET5_0_OR_GREATER
 			Assert.Equal("product_tag_id", findEntityType.FindProperty(nameof(ProductTag.ProductTagId)).GetColumnBaseName());
-		}
 #else
+			Assert.Equal("product_tag_id", findEntityType.FindProperty(nameof(ProductTag.ProductTagId)).GetColumnName());
+#endif
+		}
+
 		[Fact]
-		public void OverrideColumnNaming()
+		public void OverrideConstraintNaming()
 		{
-			ProductContext context = GetContext(namingOptions: new NamingOptions().OverrideColumnNaming(NamingScheme.SnakeCase));
+			ProductContext context = GetContext(namingOptions: new NamingOptions().OverrideConstraintNaming(NamingScheme.SnakeCase));
 
 			IEntityType findEntityType = context.Model.FindEntityType(typeof(ProductTag));
-
-			Assert.Equal("product_tag_id", findEntityType.FindProperty(nameof(ProductTag.ProductTagId)).GetColumnName());
-		}
-#endif
+			Assert.Equal("ProductTag", findEntityType.GetTableName());
 
 #if NET5_0_OR_GREATER
-		[Fact]
-		public void OverrideConstraintNaming()
-		{
-			ProductContext context = GetContext(namingOptions: new NamingOptions().OverrideConstraintNaming(NamingScheme.SnakeCase));
-
-			IEntityType findEntityType = context.Model.FindEntityType(typeof(ProductTag));
-			Assert.Equal("ProductTag", findEntityType.GetTableName());
 			Assert.Equal("ProductTagId", findEntityType.FindProperty(nameof(ProductTag.ProductTagId)).GetColumnBaseName());
-			Assert.True(findEntityType.GetKeys().All(x => x.GetName() == NamingScheme.SnakeCase(x.GetDefaultName())));
-			Assert.True(findEntityType.GetForeignKeys().All(x => x.GetConstraintName() == NamingScheme.SnakeCase(x.GetDefaultName())));
-			Assert.True(findEntityType.GetIndexes().All(x => x.GetDatabaseName() == NamingScheme.SnakeCase(x.GetDefaultDatabaseName())));
-		}
 #else
-		[Fact]
-		public void OverrideConstraintNaming()
-		{
-			ProductContext context = GetContext(namingOptions: new NamingOptions().OverrideConstraintNaming(NamingScheme.SnakeCase));
-
-			IEntityType findEntityType = context.Model.FindEntityType(typeof(ProductTag));
-			Assert.Equal("ProductTag", findEntityType.GetTableName());
 			Assert.Equal("ProductTagId", findEntityType.FindProperty(nameof(ProductTag.ProductTagId)).GetColumnName());
+#endif
+
 			Assert.True(findEntityType.GetKeys().All(x => x.GetName() == NamingScheme.SnakeCase(x.GetDefaultName())));
 			Assert.True(findEntityType.GetForeignKeys().All(x => x.GetConstraintName() == NamingScheme.SnakeCase(x.GetDefaultName())));
+
+#if NET5_0_OR_GREATER
+			Assert.True(findEntityType.GetIndexes().All(x => x.GetDatabaseName() == NamingScheme.SnakeCase(x.GetDefaultDatabaseName())));
+#else
 			Assert.True(findEntityType.GetIndexes().All(x => x.GetName() == NamingScheme.SnakeCase(x.GetDefaultName())));
-		}
 #endif
+		}
 
 		[Fact]
 		public void OverrideTableNaming()

--- a/test/SpatialFocus.EntityFrameworkCore.Extensions.Test/SpatialFocus.EntityFrameworkCore.Extensions.Test.csproj
+++ b/test/SpatialFocus.EntityFrameworkCore.Extensions.Test/SpatialFocus.EntityFrameworkCore.Extensions.Test.csproj
@@ -1,22 +1,37 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\SpatialFocus.EntityFrameworkCore.Extensions\SpatialFocus.EntityFrameworkCore.Extensions.csproj" />
-  </ItemGroup>
+	<!-- Conditionally obtain references for the netcoreapp3.1 target -->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
+	</ItemGroup>
+
+	<!-- Conditionally obtain references for the net5.0 target -->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.12" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.12" />
+	</ItemGroup>
+
+	<!-- Conditionally obtain references for the net6.0 target -->
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\SpatialFocus.EntityFrameworkCore.Extensions\SpatialFocus.EntityFrameworkCore.Extensions.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/test/SpatialFocus.EntityFrameworkCore.Extensions.Test/SpatialFocus.EntityFrameworkCore.Extensions.Test.csproj
+++ b/test/SpatialFocus.EntityFrameworkCore.Extensions.Test/SpatialFocus.EntityFrameworkCore.Extensions.Test.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="3.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="3.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
This library currently doesn't work for projects upgrading from .NET 5 to .NET 6. Calls to `EnumLookupExtension.ConfigureEnumLookup` fail with `MissingMethodException`:

```
Message: 
System.MissingMethodException : Method not found: 'Boolean Microsoft.EntityFrameworkCore.EntityTypeExtensions.IsOwned(Microsoft.EntityFrameworkCore.Metadata.IEntityType)'.
```

This PR re-targets this library to .NET 6 so that it can support working with EF Core 6. This is a major breaking change as this PR will cause support for anything before .NET 6 to be dropped. I'm not sure if it's possible to multi-target both simultaneously, but if it can then that would be excellent.

The changes made to `NamingExtension` need review as I had to replace some of the method invocations there to get the project to compile. I'm not sure if the changes I made perform strictly the same behaviour but all the tests continue to pass.